### PR TITLE
Properly handle recursive datasets.

### DIFF
--- a/zfs-snapshot-cleaner
+++ b/zfs-snapshot-cleaner
@@ -134,7 +134,7 @@ sub get_snapshots {
     my $fs = shift;
 
     my( $success, $error_message, $full_buf, $stdout_buf, $stderr_buf ) =
-        run( command => [qw(zfs list -t snapshot -H -r), $fs], verbose => 0 );
+        run( command => [qw(zfs list -t snapshot -H -d 1), $fs], verbose => 0 );
 
     if (@$stderr_buf) {
         die "zfs list returned:\n", join "\n", @$stderr_buf, "";

--- a/zfs-snapshot-cleaner
+++ b/zfs-snapshot-cleaner
@@ -44,6 +44,8 @@ GetOptions(
 
 	   'n!'	=> \(my $opt_noexecute = 0),
 
+           'recurse|r' => \(my $opt_recurse = 0),
+
            'debug!'  => \(my $debug),
            'verbose+' => \(my $verbose = -t STDIN ? 1 : 0),
 );
@@ -55,6 +57,10 @@ sub pdebug { print join(" ", @_), "\n" if $debug }
 sub plog   { print join(" ", @_), "\n" if $verbose || $debug }
 
 # if verbose, show the keep schedule
+
+if ($opt_recurse) {
+    @fs = (map get_subdatasets($_), @fs)
+}
 
 for my $fs (@fs) {
     plog "Trimming $fs";
@@ -128,6 +134,19 @@ for my $fs (@fs) {
 
     plog("Snapshots purged: $purged") if $purged;
 
+}
+
+sub get_subdatasets {
+    my $fs = shift;
+    no warnings qw(qw);
+    my( $success, $error_message, $full_buf, $stdout_buf, $stderr_buf ) =
+        run( command => [qw(zfs list -r -o name -t volume,filesystem -H), $fs], verbose => 0 );
+
+    if (@$stderr_buf) {
+        die "zfs list returned:\n", join "\n", @$stderr_buf, "";
+    }
+    my @zfs_lines = map { split /\n/ } join "", @$stdout_buf;
+    return @zfs_lines;
 }
 
 sub get_snapshots {

--- a/zfs-snapshot-cleaner
+++ b/zfs-snapshot-cleaner
@@ -175,8 +175,6 @@ sub get_snapshots {
         # From Date::Parser
         if ($date =~ m/(\d{4})([-:_]?)(\d\d?)\2(\d\d?)(?:[-Tt_ ](\d\d?)(?:([:-]?)(\d\d?)(?:\6(\d\d?)(?:[.,](\d+))?)?)?)?$/) {
             my ($year,$month,$day,$hh,$mm,$ss,$frac) = ($1,$3,$4,$5,$7,$8,$9);
-            print join "-", map { $_ || 'undef' } ($year,$month,$day,$hh,$mm,$ss,$frac);
-            print "\n";
             $date = DateTime->new( year => $year,
                                    month => $month,
                                    day => $day,


### PR DESCRIPTION
With this PR, 

```zfs-snapshot-cleaner -r tank```

does the right thing.

Before, it wouldn't treat

tank/foo
tank/bar

as independent for the calculation of how snapshots to keep.